### PR TITLE
Fix sync log ID constraint violation

### DIFF
--- a/humane-tracker/src/services/syncLogService.ts
+++ b/humane-tracker/src/services/syncLogService.ts
@@ -20,9 +20,9 @@ export class SyncLogService {
 		data?: unknown,
 	): Promise<void> {
 		try {
-			// Add the new log
+			// Add the new log with 'syn' prefix for Dexie Cloud @id compatibility
 			await this.syncLogsTable.add({
-				id: crypto.randomUUID(),
+				id: `syn${crypto.randomUUID()}`,
 				timestamp: new Date(),
 				eventType,
 				level,


### PR DESCRIPTION
## Summary
- Fixes Dexie Cloud constraint violation for syncLogs table
- Updated ID generation to use 'syn' prefix required by @id primary keys
- Minimal change: `crypto.randomUUID()` → `syn${crypto.randomUUID()}`

## Test plan
- [x] All 153 unit tests pass including 18 syncLogService tests
- [x] Pre-commit hooks pass (Biome + unit tests)
- [x] Change verified to resolve constraint violation in issue #30

Fixes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)