### PR TITLE
Add self-signed certificate support for HTTPS in containers

### DIFF
--- a/humane-tracker/package-lock.json
+++ b/humane-tracker/package-lock.json
@@ -24,6 +24,7 @@
         "@types/node": "^24.10.1",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
+        "@vitejs/plugin-basic-ssl": "^2.1.0",
         "@vitejs/plugin-react": "^4.5.2",
         "fake-indexeddb": "^6.2.5",
         "jsdom": "^26.1.0",
@@ -3096,6 +3097,19 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-basic-ssl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-2.1.0.tgz",
+      "integrity": "sha512-dOxxrhgyDIEUADhb/8OlV9JIqYLgos03YorAueTIeOUskLJSEsfwCByjbu98ctXitUN3znXKp0bYD/WHSudCeA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^6.0.0 || ^7.0.0"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",

--- a/humane-tracker/package.json
+++ b/humane-tracker/package.json
@@ -31,6 +31,7 @@
     "@types/node": "^24.10.1",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-basic-ssl": "^2.1.0",
     "@vitejs/plugin-react": "^4.5.2",
     "fake-indexeddb": "^6.2.5",
     "jsdom": "^26.1.0",

--- a/humane-tracker/vite.config.ts
+++ b/humane-tracker/vite.config.ts
@@ -1,6 +1,7 @@
 /// <reference types="vitest" />
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import basicSsl from "@vitejs/plugin-basic-ssl";
 import { VitePWA } from "vite-plugin-pwa";
 import { execSync } from "child_process";
 import { existsSync } from "fs";
@@ -40,14 +41,19 @@ const tailscaleIP = getTailscaleIP();
 const tailscaleHosts = getTailscaleHostnames();
 const devHost = inContainer && tailscaleIP ? "0.0.0.0" : "localhost";
 
+// Enable SSL when in container with Tailscale (some browser APIs require secure context)
+const useSsl = inContainer && tailscaleIP !== null;
+
 if (inContainer && tailscaleIP) {
 	console.log(`🐳 Container with Tailscale - binding to 0.0.0.0`);
-	console.log(`   Access via: http://${tailscaleHosts?.short || tailscaleIP}:3000/`);
+	const protocol = useSsl ? "https" : "http";
+	console.log(`   Access via: ${protocol}://${tailscaleHosts?.short || tailscaleIP}:3000/`);
 }
 
 export default defineConfig({
 	plugins: [
 		react(),
+		...(useSsl ? [basicSsl()] : []),
 		VitePWA({
 			registerType: "autoUpdate",
 			includeAssets: ["favicon.ico"],


### PR DESCRIPTION
## Summary
Enable HTTPS with self-signed certificates when running in a container with Tailscale, following the same pattern as `idvorkin/magic-monitor`.

## Changes
- Install `@vitejs/plugin-basic-ssl` dependency
- Conditionally enable `basicSsl()` plugin when in container with Tailscale  
- Update console output to show `https://` URL when SSL is enabled
- No manual certificate generation needed - handled automatically by the plugin

## Why?
This enables secure context for browser APIs (like camera, geolocation, etc.) that require HTTPS, while keeping local development simple (HTTP only).

## Testing
- ✅ Unit tests pass
- ✅ Build successful
- ✅ Shows `https://c-5002:3000/` in container with Tailscale
- ✅ Shows `http://localhost:3000` in local development

## Pattern Source
Based on implementation from https://github.com/idvorkin/magic-monitor