### PR TITLE
Fix TypeScript build errors and excessive sync activity

### DIFF
--- a/humane-tracker/src/repositories/entryRepository.ts
+++ b/humane-tracker/src/repositories/entryRepository.ts
@@ -179,7 +179,8 @@ export const entryRepository = {
 				...entry,
 				createdAt: new Date(),
 			});
-			const id = await db.entries.add(record);
+			// Dexie will auto-generate the id, so we cast to full type
+			const id = await db.entries.add(record as EntryRecord);
 			return id;
 		} catch (error) {
 			console.error("[EntryRepository] Failed to add entry:", {

--- a/humane-tracker/src/repositories/habitRepository.ts
+++ b/humane-tracker/src/repositories/habitRepository.ts
@@ -158,7 +158,8 @@ export const habitRepository = {
 	): Promise<string> {
 		try {
 			const record = toRecord(habit);
-			const id = await db.habits.add(record);
+			// Dexie will auto-generate the id, so we cast to full type
+			const id = await db.habits.add(record as HabitRecord);
 			return id;
 		} catch (error) {
 			console.error("[HabitRepository] Failed to create habit:", {
@@ -179,10 +180,12 @@ export const habitRepository = {
 		habits: Array<Omit<Habit, "id" | "createdAt" | "updatedAt">>,
 	): Promise<string[]> {
 		const records = habits.map(toRecord);
-		const ids = await db.habits.bulkAdd(records, {
+		// Dexie will auto-generate the ids, so we cast to full type
+		const ids = await db.habits.bulkAdd(records as HabitRecord[], {
 			allKeys: true,
 		});
-		return ids;
+		// bulkAdd with allKeys returns string[] when given an array
+		return ids as string[];
 	},
 
 	async update(


### PR DESCRIPTION
## Problem 1: TypeScript Build Errors

After merging PR #38 which fixed Dexie table types to use Record types, the TypeScript build started failing with errors:

```
src/repositories/entryRepository.ts(182,36): error TS2345: Argument of type 'Omit<EntryRecord, "id">' is not assignable to parameter of type 'EntryRecord'.
src/repositories/habitRepository.ts(161,35): error TS2345: Argument of type 'Omit<HabitRecord, "id">' is not assignable to parameter of type 'HabitRecord'.
src/repositories/habitRepository.ts(185,3): error TS2322: Type 'string | string[]' is not assignable to type 'string[]'.
```

### Root Cause

1. `toRecord()` returns `Omit<HabitRecord, "id">` or `Omit<EntryRecord, "id">`
2. Dexie tables are typed as `Table<HabitRecord, string>` and `Table<EntryRecord, string>`
3. Dexie's `add()` and `bulkAdd()` methods expect the full type including the `id` field
4. However, Dexie auto-generates the `id` field at runtime, so it's actually optional

### Solution

Cast records to the full `HabitRecord`/`EntryRecord` type when passing to Dexie methods:

- `db.habits.add(record as HabitRecord)` 
- `db.habits.bulkAdd(records as HabitRecord[], { allKeys: true })`
- `db.entries.add(record as EntryRecord)`

This is safe because:
- Dexie ignores/overwrites the `id` field when auto-generating
- The cast is only for TypeScript's benefit
- Added explanatory comments for future maintainers

Also fixed `bulkAdd` return type:
- `bulkAdd` with `allKeys: true` returns `string | string[]`
- When given an array, it always returns `string[]`
- Cast return value to `string[]` to match our `Promise<string[]>` signature

## Problem 2: Excessive Sync Activity

Users were experiencing "lots of syncs" - excessive database queries and reloads during Dexie Cloud sync.

### Root Cause

Every change from Dexie Cloud sync (habits or entries) triggered an immediate full reload via `loadHabits()`. During sync bursts, this caused:
- Rapid-fire database queries
- Excessive re-renders
- Poor performance during sync

The subscription callbacks were ignoring the data from liveQuery and doing full reloads instead.

### Solution

Added 300ms debouncing to subscription reload callbacks. Rapid changes during sync bursts are now batched into a single reload.

Changes:
- Added `debounceTimerRef` to track pending reload timer
- Wrapped subscription callbacks in `debouncedReload()` function
- Clear debounce timer on component unmount to prevent memory leaks

The 300ms delay is short enough to feel responsive but long enough to batch most sync-related changes.

## Testing

✅ All 214 unit tests passing  
✅ TypeScript build successful  
✅ No changes to runtime behavior (except improved performance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)