### PR TITLE
ggFix category summary calculation to count actual entries

### DIFF
--- a/humane-tracker/src/hooks/useHabitTrackerVM.test.ts
+++ b/humane-tracker/src/hooks/useHabitTrackerVM.test.ts
@@ -490,21 +490,52 @@ describe("groupHabitsByCategory", () => {
 
 describe("calculateSummaryStats", () => {
 	it("calculates all stats correctly", () => {
+		const today = new Date();
 		const habits = [
-			createMockHabit({ status: "today" }),
-			createMockHabit({ status: "today" }),
-			createMockHabit({ status: "overdue" }),
-			createMockHabit({ status: "done" }),
-			createMockHabit({ status: "met" }),
-			createMockHabit({ status: "met" }),
+			createMockHabit({
+				status: "today",
+				entries: [],
+				currentWeekCount: 0,
+				targetPerWeek: 3,
+			}),
+			createMockHabit({
+				status: "today",
+				entries: [],
+				currentWeekCount: 1,
+				targetPerWeek: 3,
+			}),
+			createMockHabit({
+				status: "overdue",
+				entries: [],
+				currentWeekCount: 0,
+				targetPerWeek: 3,
+			}),
+			createMockHabit({
+				status: "done",
+				entries: [{ id: "e1", habitId: "h1", userId: "u1", date: today, value: 1, createdAt: new Date() }],
+				currentWeekCount: 3,
+				targetPerWeek: 3,
+			}),
+			createMockHabit({
+				status: "met",
+				entries: [],
+				currentWeekCount: 3,
+				targetPerWeek: 3,
+			}),
+			createMockHabit({
+				status: "met",
+				entries: [],
+				currentWeekCount: 2,
+				targetPerWeek: 2,
+			}),
 		];
 
 		const stats = calculateSummaryStats(habits);
 
 		expect(stats.dueToday).toBe(2);
 		expect(stats.overdue).toBe(1);
-		expect(stats.doneToday).toBe(1);
-		expect(stats.onTrack).toBe(3); // done + 2 met = 3 on track
+		expect(stats.doneToday).toBe(1); // Only 1 habit has entry today
+		expect(stats.onTrack).toBe(3); // 3 habits met their weekly target (currentWeekCount >= targetPerWeek)
 	});
 
 	it("returns zeros for empty habits", () => {

--- a/humane-tracker/src/hooks/useHabitTrackerVM.ts
+++ b/humane-tracker/src/hooks/useHabitTrackerVM.ts
@@ -104,12 +104,21 @@ export function getCellDisplay(
 }
 
 export function calculateSummaryStats(habits: HabitWithStatus[]): SummaryStats {
+	// Count habits with entries for today (not just status "done")
+	const todayStr = toDateString(new Date());
+	const doneToday = habits.filter((h) =>
+		h.entries.some((e) => toDateString(e.date) === todayStr && e.value >= 1),
+	).length;
+
+	// Count habits that met their weekly target
+	const onTrack = habits.filter((h) => h.currentWeekCount >= h.targetPerWeek)
+		.length;
+
 	return {
 		dueToday: habits.filter((h) => h.status === "today").length,
 		overdue: habits.filter((h) => h.status === "overdue").length,
-		doneToday: habits.filter((h) => h.status === "done").length,
-		onTrack: habits.filter((h) => h.status === "met" || h.status === "done")
-			.length,
+		doneToday,
+		onTrack,
 	};
 }
 


### PR DESCRIPTION
Fixes #22

The category summary was counting habits based on their status field, which caused habits with entries but status "pending" to not be counted.

## Changes
- getCategorySummary now counts habits with actual entries for "done today"
- Uses currentWeekCount >= targetPerWeek for "met this week" count
- Updated all tests to provide proper entries and currentWeekCount data

---

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved habit completion metrics to accurately reflect actual daily entries and weekly progress data, ensuring habit status calculations are based on real tracking information rather than status flags alone.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->