### PR TITLE
refactor: extract shared utilities and use hooks for HabitService

### DIFF
--- a/humane-tracker/src/components/CleanupDuplicates.tsx
+++ b/humane-tracker/src/components/CleanupDuplicates.tsx
@@ -1,9 +1,7 @@
 import type React from "react";
 import { useState } from "react";
-import { HabitService } from "../services/habitService";
+import { useHabitService } from "../hooks/useHabitService";
 import type { Habit } from "../types/habit";
-
-const habitService = new HabitService();
 
 interface CleanupDuplicatesProps {
 	userId: string;
@@ -14,6 +12,7 @@ export const CleanupDuplicates: React.FC<CleanupDuplicatesProps> = ({
 	userId,
 	onComplete,
 }) => {
+	const habitService = useHabitService();
 	const [isProcessing, setIsProcessing] = useState(false);
 	const [status, setStatus] = useState<string>("");
 	const [duplicatesFound, setDuplicatesFound] = useState<string[]>([]);

--- a/humane-tracker/src/components/HabitEditor.tsx
+++ b/humane-tracker/src/components/HabitEditor.tsx
@@ -1,8 +1,9 @@
 import type React from "react";
 import { useState } from "react";
-import { HabitService } from "../services/habitService";
+import { useHabitService } from "../hooks/useHabitService";
 import type { Habit } from "../types/habit";
 import { buildCategoryInfo } from "../utils/categoryUtils";
+import { validateHabitForm } from "../utils/habitValidation";
 import "./HabitSettings.css";
 
 interface HabitEditorProps {
@@ -44,17 +45,13 @@ export const HabitEditor: React.FC<HabitEditorProps> = ({
 	const [isSaving, setIsSaving] = useState(false);
 	const [error, setError] = useState("");
 
-	const habitService = new HabitService();
+	const habitService = useHabitService();
 	const categoryInfo = buildCategoryInfo(category);
 
 	const handleSave = async () => {
-		if (!name.trim()) {
-			setError("Habit name is required");
-			return;
-		}
-
-		if (!category.trim()) {
-			setError("Category is required");
+		const validation = validateHabitForm({ name, category });
+		if (!validation.isValid) {
+			setError(validation.errors.name || validation.errors.category || "");
 			return;
 		}
 

--- a/humane-tracker/src/components/HabitManager.tsx
+++ b/humane-tracker/src/components/HabitManager.tsx
@@ -1,10 +1,9 @@
 import type React from "react";
 import { useState } from "react";
-import { HabitService } from "../services/habitService";
+import { useHabitService } from "../hooks/useHabitService";
 import { buildCategoryInfo } from "../utils/categoryUtils";
+import { validateHabitForm } from "../utils/habitValidation";
 import "./HabitManager.css";
-
-const habitService = new HabitService();
 
 interface HabitManagerProps {
 	userId: string;
@@ -17,6 +16,7 @@ export const HabitManager: React.FC<HabitManagerProps> = ({
 	onClose,
 	existingCategories,
 }) => {
+	const habitService = useHabitService();
 	const [habitName, setHabitName] = useState("");
 	const [category, setCategory] = useState("Mobility");
 	const [targetPerWeek, setTargetPerWeek] = useState(3);
@@ -26,8 +26,8 @@ export const HabitManager: React.FC<HabitManagerProps> = ({
 
 	const handleSubmit = async (e: React.FormEvent) => {
 		e.preventDefault();
-		if (!habitName.trim()) return;
-		if (!category.trim()) return;
+		const validation = validateHabitForm({ name: habitName, category });
+		if (!validation.isValid) return;
 
 		setLoading(true);
 		try {

--- a/humane-tracker/src/components/HabitSettings.tsx
+++ b/humane-tracker/src/components/HabitSettings.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
 import { useEffect, useRef, useState } from "react";
+import { useHabitService } from "../hooks/useHabitService";
 import {
 	type ExportData,
 	exportAllData,
@@ -7,13 +8,13 @@ import {
 	importAllData,
 	validateExportData,
 } from "../services/dataService";
-import { HabitService } from "../services/habitService";
 import type { Habit } from "../types/habit";
 import {
 	buildCategoryInfo,
 	extractCategories,
 	migrateCategoryValue,
 } from "../utils/categoryUtils";
+import { validateHabitForm } from "../utils/habitValidation";
 import "./HabitSettings.css";
 
 interface HabitSettingsProps {
@@ -59,7 +60,7 @@ export const HabitSettings: React.FC<HabitSettingsProps> = ({
 	const fileInputRef = useRef<HTMLInputElement>(null);
 	const hasInitializedCollapse = useRef(false);
 
-	const habitService = new HabitService();
+	const habitService = useHabitService();
 
 	// Derive existing categories from habits
 	const existingCategories = extractCategories(habits);
@@ -137,13 +138,12 @@ export const HabitSettings: React.FC<HabitSettingsProps> = ({
 	};
 
 	const handleAddNewHabit = async () => {
-		if (!newHabit.name.trim()) {
-			alert("Please enter a habit name");
-			return;
-		}
-
-		if (!newHabit.category.trim()) {
-			alert("Please enter a category");
+		const validation = validateHabitForm({
+			name: newHabit.name,
+			category: newHabit.category,
+		});
+		if (!validation.isValid) {
+			alert(validation.errors.name || validation.errors.category);
 			return;
 		}
 

--- a/humane-tracker/src/components/InitializeHabits.tsx
+++ b/humane-tracker/src/components/InitializeHabits.tsx
@@ -1,11 +1,9 @@
 import type React from "react";
 import { useState } from "react";
 import { DEFAULT_HABITS } from "../data/defaultHabits";
-import { HabitService } from "../services/habitService";
+import { useHabitService } from "../hooks/useHabitService";
 import { buildCategoryInfo, extractCategories } from "../utils/categoryUtils";
 import "./InitializeHabits.css";
-
-const habitService = new HabitService();
 
 interface InitializeHabitsProps {
 	userId: string;
@@ -16,6 +14,7 @@ export const InitializeHabits: React.FC<InitializeHabitsProps> = ({
 	userId,
 	onComplete,
 }) => {
+	const habitService = useHabitService();
 	const [loading, setLoading] = useState(false);
 	const [progress, setProgress] = useState(0);
 

--- a/humane-tracker/src/hooks/useHabitService.ts
+++ b/humane-tracker/src/hooks/useHabitService.ts
@@ -1,0 +1,10 @@
+import { useMemo } from "react";
+import { HabitService } from "../services/habitService";
+
+/**
+ * Hook that provides a stable HabitService instance.
+ * This keeps HabitService instantiation in the hooks layer per CLAUDE.md.
+ */
+export function useHabitService(): HabitService {
+	return useMemo(() => new HabitService(), []);
+}

--- a/humane-tracker/src/hooks/useHabitTrackerVM.ts
+++ b/humane-tracker/src/hooks/useHabitTrackerVM.ts
@@ -10,6 +10,7 @@ import type {
 	SummaryStats,
 } from "../types/habit";
 import { buildCategoryInfo, extractCategories } from "../utils/categoryUtils";
+import { getTrailingWeekDateRange } from "../utils/dateUtils";
 
 const habitService = new HabitService();
 
@@ -289,11 +290,7 @@ export function useHabitTrackerVM({
 			handleSubscriptionError,
 		);
 
-		const endDate = new Date();
-		endDate.setHours(23, 59, 59, 999);
-		const startDate = new Date();
-		startDate.setDate(startDate.getDate() - 6);
-		startDate.setHours(0, 0, 0, 0);
+		const { startDate, endDate } = getTrailingWeekDateRange();
 
 		const unsubscribeEntries = habitService.subscribeToWeekEntries(
 			userId,

--- a/humane-tracker/src/repositories/index.ts
+++ b/humane-tracker/src/repositories/index.ts
@@ -1,11 +1,12 @@
 export { entryRepository } from "./entryRepository";
 export { habitRepository } from "./habitRepository";
+export { runImportTransaction } from "./transactions";
+export type { EntryRecord, HabitRecord } from "./types";
 export {
-	toDateString,
 	fromDateString,
-	toTimestamp,
 	fromTimestamp,
 	normalizeDate,
 	normalizeDateString,
+	toDateString,
+	toTimestamp,
 } from "./types";
-export type { EntryRecord, HabitRecord } from "./types";

--- a/humane-tracker/src/repositories/transactions.ts
+++ b/humane-tracker/src/repositories/transactions.ts
@@ -1,0 +1,26 @@
+import { db } from "../config/db";
+import type { Habit, HabitEntry } from "../types/habit";
+import { entryRepository } from "./entryRepository";
+import { habitRepository } from "./habitRepository";
+
+/**
+ * Run an import operation atomically across habits and entries tables.
+ * If any operation fails, all changes are rolled back.
+ *
+ * This function exists to keep db.transaction() usage confined to the repository layer.
+ */
+export async function runImportTransaction(
+	habits: Habit[],
+	entries: HabitEntry[],
+	mode: "merge" | "replace",
+): Promise<void> {
+	await db.transaction("rw", db.habits, db.entries, async () => {
+		if (mode === "replace") {
+			await habitRepository.clear();
+			await entryRepository.clear();
+		}
+
+		await habitRepository.bulkPut(habits);
+		await entryRepository.bulkPut(entries);
+	});
+}

--- a/humane-tracker/src/services/habitService.ts
+++ b/humane-tracker/src/services/habitService.ts
@@ -9,6 +9,7 @@ import type {
 	HabitStatus,
 	HabitWithStatus,
 } from "../types/habit";
+import { getTrailingWeekDateRange } from "../utils/dateUtils";
 
 // ============================================================================
 // Pure functions (easily testable)
@@ -31,11 +32,8 @@ export function calculateHabitStatus(
 	currentDate: Date = new Date(),
 ): HabitStatus {
 	// Use trailing 7 days (today and 6 days back) to match UI display
-	const weekEnd = new Date(currentDate);
-	weekEnd.setHours(23, 59, 59, 999);
-	const weekStart = new Date(currentDate);
-	weekStart.setDate(weekStart.getDate() - 6);
-	weekStart.setHours(0, 0, 0, 0);
+	const { startDate: weekStart, endDate: weekEnd } =
+		getTrailingWeekDateRange(currentDate);
 
 	const todayStr = toDateString(currentDate);
 
@@ -152,12 +150,7 @@ export class HabitService {
 	async getHabitsWithStatus(userId: string): Promise<HabitWithStatus[]> {
 		const habits = await this.getUserHabits(userId);
 		const currentDate = new Date();
-		// Get trailing 7 days (today and previous 6 days)
-		const endDate = new Date(currentDate);
-		endDate.setHours(23, 59, 59, 999);
-		const startDate = new Date(currentDate);
-		startDate.setDate(startDate.getDate() - 6);
-		startDate.setHours(0, 0, 0, 0);
+		const { startDate, endDate } = getTrailingWeekDateRange(currentDate);
 
 		const habitsWithStatus: HabitWithStatus[] = [];
 

--- a/humane-tracker/src/utils/dateUtils.ts
+++ b/humane-tracker/src/utils/dateUtils.ts
@@ -1,0 +1,17 @@
+/**
+ * Get the trailing week date range (today and 6 days back).
+ * Returns start date at 00:00:00.000 and end date at 23:59:59.999.
+ */
+export function getTrailingWeekDateRange(currentDate: Date = new Date()): {
+	startDate: Date;
+	endDate: Date;
+} {
+	const endDate = new Date(currentDate);
+	endDate.setHours(23, 59, 59, 999);
+
+	const startDate = new Date(currentDate);
+	startDate.setDate(startDate.getDate() - 6);
+	startDate.setHours(0, 0, 0, 0);
+
+	return { startDate, endDate };
+}

--- a/humane-tracker/src/utils/habitValidation.ts
+++ b/humane-tracker/src/utils/habitValidation.ts
@@ -1,0 +1,33 @@
+export interface HabitFormData {
+	name: string;
+	category: string;
+}
+
+export interface ValidationResult {
+	isValid: boolean;
+	errors: {
+		name?: string;
+		category?: string;
+	};
+}
+
+/**
+ * Validate habit form data (name and category).
+ * Returns validation result with specific error messages.
+ */
+export function validateHabitForm(data: HabitFormData): ValidationResult {
+	const errors: ValidationResult["errors"] = {};
+
+	if (!data.name.trim()) {
+		errors.name = "Habit name is required";
+	}
+
+	if (!data.category.trim()) {
+		errors.category = "Category is required";
+	}
+
+	return {
+		isValid: Object.keys(errors).length === 0,
+		errors,
+	};
+}


### PR DESCRIPTION
## Summary
- Move `db.transaction()` to repository layer (`transactions.ts`) fixing repository pattern violation
- Create `useHabitService` hook, update 5 components to use it instead of direct instantiation
- Extract `getTrailingWeekDateRange()` to `dateUtils.ts` (eliminates 3 duplications)
- Extract `validateHabitForm()` to `habitValidation.ts` (eliminates 3 duplications)

## Test plan
- [x] TypeScript type checking passes
- [x] All 214 unit tests pass
- [x] Pre-commit hooks pass (biome, prettier, tsc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced atomic data import transactions supporting merge and replace modes for data consistency during bulk operations

* **Improvements**
  * Standardized form validation across all habit management screens
  * Consolidated error messaging with focused notifications instead of multiple alerts

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->