### PR TITLE
feat: add Cloudflare Pages deployment support

### DIFF
--- a/humane-tracker/justfile
+++ b/humane-tracker/justfile
@@ -130,6 +130,14 @@ install-browsers:
 deploy-stage: test build
     npx surge dist humane-tracker-stage.surge.sh
 
-# Deploy to production
+# Deploy to production (Surge)
 deploy-prod: test build
     npx surge dist humane-tracker.surge.sh
+
+# Deploy to Cloudflare Pages (production)
+deploy-cf: test build
+    npx wrangler pages deploy dist --project-name humane-tracker
+
+# Deploy to Cloudflare Pages (preview/staging)
+deploy-cf-preview: test build
+    npx wrangler pages deploy dist --project-name humane-tracker --branch preview

--- a/humane-tracker/wrangler.jsonc
+++ b/humane-tracker/wrangler.jsonc
@@ -1,0 +1,7 @@
+{
+	"name": "humane-tracker",
+	"compatibility_date": "2025-12-25",
+	"assets": {
+		"directory": "./dist"
+	}
+}


### PR DESCRIPTION
## Summary
- Add `wrangler.jsonc` config for Cloudflare Pages deployment
- Add `just deploy-cf` command for production deployment
- Add `just deploy-cf-preview` command for preview/staging deployment

## Test plan
- [ ] Run `just deploy-cf` to deploy to Cloudflare Pages (first run creates project)
- [ ] Verify site loads at Cloudflare Pages URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new deployment options for cloud-based hosting platform with both production and preview deployment targets to support different deployment scenarios
  * Added deployment configuration file specifying project settings and asset directory to properly support and streamline the new deployment targets

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->