### PR TITLE
ci: add Cloudflare Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -1,0 +1,41 @@
+name: Deploy to Cloudflare Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    name: Build and Deploy to Cloudflare Pages
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: 'humane-tracker/package-lock.json'
+
+      - name: Install dependencies
+        working-directory: ./humane-tracker
+        run: npm ci
+
+      - name: Run unit tests
+        working-directory: ./humane-tracker
+        run: npm test
+
+      - name: Build app
+        working-directory: ./humane-tracker
+        run: npm run build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy humane-tracker/dist --project-name humane-tracker


### PR DESCRIPTION
## Summary
- Adds GitHub Action to deploy to Cloudflare Pages on push to main
- Runs unit tests and build before deploying
- Uses official `cloudflare/wrangler-action@v3`

## Secrets Required
- `CLOUDFLARE_API_TOKEN` - API token with Workers/Pages permissions
- `CLOUDFLARE_ACCOUNT_ID` - Cloudflare account ID

## Test plan
- [x] Secrets configured in repo settings
- [ ] Merge PR and verify deployment triggers
- [ ] Check Cloudflare Pages dashboard for successful deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated deployment to Cloudflare Pages on pushes to the main branch.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->