### PR TITLE
ci: add workflow_dispatch to Cloudflare deploy

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger for manual deploys
- Also serves as a test now that the Cloudflare Pages project exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)