### PR TITLE
feat: rename 'Load Default Habits' to 'Load Demo Data'

### DIFF
--- a/humane-tracker/src/components/HabitTracker.tsx
+++ b/humane-tracker/src/components/HabitTracker.tsx
@@ -253,7 +253,7 @@ export const HabitTracker: React.FC<HabitTrackerProps> = ({
 							if (!vm.hasNoHabits) {
 								if (
 									!window.confirm(
-										"This will DELETE all your current habits and entries, then load the default habits. This cannot be undone. Continue?",
+										"This will DELETE all your current habits and entries, then load demo data. This cannot be undone. Continue?",
 									)
 								) {
 									return;

--- a/humane-tracker/src/components/InitializeHabits.tsx
+++ b/humane-tracker/src/components/InitializeHabits.tsx
@@ -2,8 +2,60 @@ import type React from "react";
 import { useState } from "react";
 import { DEFAULT_HABITS } from "../data/defaultHabits";
 import { useHabitService } from "../hooks/useHabitService";
+import { entryRepository } from "../repositories/entryRepository";
 import { buildCategoryInfo, extractCategories } from "../utils/categoryUtils";
 import "./InitializeHabits.css";
+
+/**
+ * Generate random completions for demo data with a realistic pattern:
+ * - ~25% of habits are skipped entirely
+ * - Recent days have higher completion probability
+ * - Covers past 14 days
+ */
+async function generateDemoCompletions(
+	habitIds: string[],
+	userId: string,
+): Promise<void> {
+	const today = new Date();
+	const DAYS_TO_FILL = 14;
+
+	for (const habitId of habitIds) {
+		// Skip ~25% of habits entirely
+		if (Math.random() < 0.25) continue;
+
+		for (let daysAgo = 0; daysAgo < DAYS_TO_FILL; daysAgo++) {
+			// Completion probability decreases with age
+			let probability: number;
+			if (daysAgo <= 2) {
+				probability = 0.6; // Recent: 60%
+			} else if (daysAgo <= 6) {
+				probability = 0.45; // Mid: 45%
+			} else {
+				probability = 0.25; // Older: 25%
+			}
+
+			if (Math.random() < probability) {
+				const date = new Date(today);
+				date.setDate(date.getDate() - daysAgo);
+
+				try {
+					await entryRepository.add({
+						habitId,
+						userId,
+						date,
+						value: 1,
+					});
+				} catch (err) {
+					// Demo data failure is non-fatal, just log and continue
+					console.warn(
+						`[InitializeHabits] Failed to create demo entry for habit ${habitId}:`,
+						err,
+					);
+				}
+			}
+		}
+	}
+}
 
 interface InitializeHabitsProps {
 	userId: string;
@@ -92,6 +144,14 @@ export const InitializeHabits: React.FC<InitializeHabitsProps> = ({
 				setProgress(Math.round(((rawHabits.length + i + 1) / total) * 100));
 			}
 
+			// Generate demo completions (non-fatal if this fails)
+			const rawHabitIds = Array.from(nameToId.values());
+			try {
+				await generateDemoCompletions(rawHabitIds, userId);
+			} catch (err) {
+				console.warn("[InitializeHabits] Demo completions failed:", err);
+			}
+
 			onComplete();
 		} catch (error) {
 			console.error("Error initializing habits:", error);
@@ -104,10 +164,12 @@ export const InitializeHabits: React.FC<InitializeHabitsProps> = ({
 	return (
 		<div className="initialize-habits">
 			<div className="init-card">
-				<h2>Welcome to Humane Tracker!</h2>
-				<p>Would you like to start with the default habit set?</p>
+				<h2>Load Demo Data</h2>
+				<p>Explore the app with sample habits and completions.</p>
 				<p className="habit-count">
 					{DEFAULT_HABITS.length} habits across {categories.length} categories
+					<br />
+					<small>Includes 2 weeks of sample completion data</small>
 				</p>
 
 				<div className="categories-preview">
@@ -140,14 +202,14 @@ export const InitializeHabits: React.FC<InitializeHabitsProps> = ({
 
 				<div className="init-actions">
 					<button className="btn-skip" onClick={onComplete} disabled={loading}>
-						Skip for now
+						Skip
 					</button>
 					<button
 						className="btn-initialize"
 						onClick={initializeDefaultHabits}
 						disabled={loading}
 					>
-						{loading ? "Initializing..." : "Initialize Default Habits"}
+						{loading ? "Loading..." : "Load Demo Data"}
 					</button>
 				</div>
 			</div>

--- a/humane-tracker/src/components/UserMenu.tsx
+++ b/humane-tracker/src/components/UserMenu.tsx
@@ -113,7 +113,7 @@ export function UserMenu({
 							{showLoadDefaults && onLoadDefaults && (
 								<MenuItem
 									icon={<DownloadIcon />}
-									label="Load Default Habits"
+									label="Load Demo Data"
 									onClick={() => {
 										closeMenu();
 										onLoadDefaults();


### PR DESCRIPTION
## Summary
- Rename menu item from "Load Default Habits" to "Load Demo Data"
- Update dialog to clarify it's sample data for exploring the app
- Add random completions over past 14 days for realistic appearance
- Demo completion failures are non-fatal (logged but don't block)

## Why
"Load Default Habits" implied a clean starting point for real tracking. "Load Demo Data" makes it clear you're getting sample data to explore the app.

## Test plan
- [ ] Click menu → "Load Demo Data"
- [ ] Verify dialog says "Load Demo Data" with description about sample completions
- [ ] Click "Load Demo Data" button
- [ ] Verify habits appear with some completions over past 2 weeks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Demo data loading now generates sample completion history spanning two weeks, with varying activity patterns across selected habits to provide a realistic starting point for new users.

* **Documentation**
  * Updated button labels, dialog prompts, and messaging throughout the initialization flow and user menu from "default habits" to "demo data" terminology to reflect the new feature.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->